### PR TITLE
Move resources to user data folder

### DIFF
--- a/src/nomadic/download/references.py
+++ b/src/nomadic/download/references.py
@@ -2,6 +2,8 @@ import os
 from nomadic.util.exceptions import ReferenceGenomeMissingError
 from abc import ABC, abstractmethod
 
+from nomadic.util.dirs import user_data_dir
+
 
 # ================================================================
 # Base classes for reference sequences
@@ -51,11 +53,9 @@ class Reference(ABC):
     def root_path():
         """
         Return the root path for where data is stored.
-        Fasta files, GFF files, and other resources will be stored in <root_path>/resources/...
+        Fasta files, GFF files, and other resources will be stored in <user_data_dir>/resources/...
         """
-        # does not work at the moment, because we don't handle spaces correctly in the path
-        # return user_data_dir()
-        return "."
+        return user_data_dir()
 
     def confirm_downloaded(self) -> None:
         """

--- a/src/nomadic/start/commands.py
+++ b/src/nomadic/start/commands.py
@@ -1,6 +1,5 @@
 import enum
 import os
-from contextlib import chdir
 from importlib.resources import files
 
 import click
@@ -56,10 +55,7 @@ def setup_pfalciparum(workspace):
 
     reference_name = "Pf3D7"
 
-    # workaround for that we can not set the root in download_reference
-    with chdir(workspace.path):
-        download_reference(reference_name)
-        pass
+    download_reference(reference_name)
 
     copy_bed_files(workspace, Organism.pfalciparum.name)
 


### PR DESCRIPTION
This way user data does not have to be redownloaded when switching workspaces and we can actually run nomadic from out side of a workspace, as before resources where always searched for in cwd.

Goal is to merge to main, opened to previous branch so changes are easier to so. Github will automatically update the base to develop when the other PR is merged.