### PR TITLE
Handle also tab limited metadata files

### DIFF
--- a/src/nomadic/util/metadata.py
+++ b/src/nomadic/util/metadata.py
@@ -5,7 +5,7 @@ from typing import List
 from .exceptions import MetadataFormatError
 
 
-def get_csv_delimiter(csv_path: str, delimiters: List[str] = [",", ";"]):
+def get_csv_delimiter(csv_path: str, delimiters: List[str] = [",", ";", "\t"]):
     """
     Determine which delimiter is being used in a CSV
 


### PR DESCRIPTION
I could not use the metadata example file you added, and it might be because we should have this?

Could it be that they have tabs in their sample ids or so? That could cause problems, but they should not I assume. 

