### PR TITLE
Use commas instead of tabs in example metadata

### DIFF
--- a/src/nomadic/start/data/0000-00-00_example.csv
+++ b/src/nomadic/start/data/0000-00-00_example.csv
@@ -1,17 +1,17 @@
-barcode	sample_id	sample_type	location	parasitemia	postclean_qubit
-barcode01	3D7	pos	berlin	1000	87
-barcode02	Dd2	pos	berlin	1000	76
-barcode03	HB3	pos	berlin	100	34
-barcode04	NTC	neg	berlin	0	0
-barcode05	DBS-A01	field	berlin	543	44
-barcode06	DBS-A02	field	berlin	7583	85
-barcode07	DBS-A03	field	berlin	349	32
-barcode08	DBS-B01	field	berlin	239	25
-barcode09	DBS-B02	field	berlin	200	21
-barcode10	DBS-B03	field	berlin	10923	95
-barcode11	DBS-B04	field	berlin	5670	63
-barcode12	DBS-B05	field	berlin	436	44
-barcode13	DBS-B06	field	berlin	3459	70
-barcode14	DBS-B07	field	berlin	489	23
-barcode15	DBS-B08	field	berlin	42	10
-barcode16	DBS-B09	field	berlin	850	49
+﻿barcode,sample_id,sample_type,location,parasitemia,postclean_qubit
+barcode01,3D7,pos,berlin,1000,87
+barcode02,Dd2,pos,berlin,1000,76
+barcode03,HB3,pos,berlin,100,34
+barcode04,NTC,neg,berlin,0,0
+barcode05,DBS-A01,field,berlin,543,44
+barcode06,DBS-A02,field,berlin,7583,85
+barcode07,DBS-A03,field,berlin,349,32
+barcode08,DBS-B01,field,berlin,239,25
+barcode09,DBS-B02,field,berlin,200,21
+barcode10,DBS-B03,field,berlin,10923,95
+barcode11,DBS-B04,field,berlin,5670,63
+barcode12,DBS-B05,field,berlin,436,44
+barcode13,DBS-B06,field,berlin,3459,70
+barcode14,DBS-B07,field,berlin,489,23
+barcode15,DBS-B08,field,berlin,42,10
+barcode16,DBS-B09,field,berlin,850,49


### PR DESCRIPTION
Small thing but I think because it is .csv we should use commas