### PR TITLE
Fix not having to press control c twice

### DIFF
--- a/src/nomadic/realtime/dashboard/builders.py
+++ b/src/nomadic/realtime/dashboard/builders.py
@@ -99,7 +99,7 @@ class RealtimeDashboardBuilder(ABC):
 
         if in_thread:
             dashboard_thread = threading.Thread(
-                target=lambda: app.run(**kwargs), name="dashboard"
+                target=lambda: app.run(**kwargs), name="dashboard", daemon=True
             )
             dashboard_thread.start()
         else:


### PR DESCRIPTION
This only fixes the issue that we had to press control c twice. it will set deamon=True, which tells python it does not have to wait for that thread to finish.

This is not implementing a clean shutdown yet, but because we have the worklog we maybe dont have to. 