### PR TITLE
Allow fastqdir path to not exist yet

### DIFF
--- a/src/nomadic/realtime/commands.py
+++ b/src/nomadic/realtime/commands.py
@@ -154,7 +154,7 @@ def realtime(
                 message=f"Region BED file not found at {region_bed}.",
             )
 
-    if not minknow.is_fastq_dir(fastq_dir) and experiment_name not in fastq_dir:
+    if not minknow.is_fastq_dir(fastq_dir):
         # should be base path of minknow data, build fastq glob with experiment name.
         fastq_dir = minknow.fastq_dir_glob(fastq_dir, experiment_name)
 

--- a/src/nomadic/realtime/commands.py
+++ b/src/nomadic/realtime/commands.py
@@ -7,7 +7,7 @@ from nomadic.util.workspace import (
     Workspace,
     looks_like_a_bed_filepath,
 )
-from nomadic.util.minknow import default_fastq_dir
+from nomadic.util import minknow
 from nomadic.util.config import load_config, default_config_path
 
 
@@ -63,8 +63,9 @@ def load_defaults_from_config(ctx, param, value):
     "-f",
     "--fastq_dir",
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    show_default="/var/lib/minknow/data/<experiment_name>/fastq_pass",
-    help="Path to `fastq_pass` directory produced by MinKNOW or Guppy.",
+    default="/var/lib/minknow/data",
+    show_default=True,
+    help="Path to `fastq_pass` output directory of minknow (e.g. `/var/lib/minknow/data/<experiment_name>/.../.../fastq_pass`), or to the general output directory of minknow (e.g. `/var/lib/minknow/data`)",
 )
 @click.option(
     "-m",
@@ -153,12 +154,9 @@ def realtime(
                 message=f"Region BED file not found at {region_bed}.",
             )
 
-    if fastq_dir is None:
-        fastq_dir = default_fastq_dir(experiment_name)
-        if not os.path.isdir(fastq_dir):
-            raise click.BadParameter(
-                message=f"FASTQ directory not found at {fastq_dir}. Does {experiment_name} match the minknow experiment name and is minknow already running long enough?",
-            )
+    if not minknow.is_fastq_dir(fastq_dir) and experiment_name not in fastq_dir:
+        # should be base path of minknow data, build fastq glob with experiment name.
+        fastq_dir = minknow.fastq_dir_glob(fastq_dir, experiment_name)
 
     if reference_name is None:
         raise click.BadParameter(

--- a/src/nomadic/realtime/factory.py
+++ b/src/nomadic/realtime/factory.py
@@ -87,7 +87,8 @@ class PipelineFactory:
         """
         return [
             BarcodeWatcher(
-                barcode_fastq_dir=f"{self.fastq_dir}/{b}",
+                barcode=b,
+                fastq_dir=self.fastq_dir,
                 barcode_pipeline=self._get_barcode_pipeline(barcode_name=b),
                 work_log_path=f"{self.expt_dirs.get_barcode_dir(b)}/.work.log",
             )

--- a/src/nomadic/util/minknow.py
+++ b/src/nomadic/util/minknow.py
@@ -1,21 +1,37 @@
 import glob
 import warnings
+import os
+from typing import Optional
 
 
-def default_fastq_dir(experiment_name: str) -> str:
+def fastq_dir(fastq_dir_glob: str) -> Optional[str]:
     """
     Return the default FASTQ directory for MinKNOW experiments.
     This is typically where Minknow/Guppy writes the FASTQ files.
 
     """
-    fastq_pass_dirs = glob.glob(
-        f"/var/lib/minknow/data/{experiment_name}/*/*/fastq_pass"
-    )
+    fastq_pass_dirs = glob.glob(fastq_dir_glob)
     if len(fastq_pass_dirs) > 1:
         warnings.warn(
             f"Found {len(fastq_pass_dirs)} 'fastq_pass' directories,"
             " This suggests more than one experiment with this name has"
             " been run from MinKNOW. Will proceed with most recent."
         )
+    if len(fastq_pass_dirs) < 1:
+        warnings.warn(
+            f"Found no 'fastq_pass' directories in '{fastq_dir_glob}',"
+            " If you just started minknow, this can mean the files have not been created yet."
+            " If minknow is already running for more than 10 minutes, check if your experiment"
+            " name matches minknow's experiment name."
+        )
+        return None
 
     return fastq_pass_dirs[-1]
+
+
+def is_fastq_dir(path: str) -> bool:
+    return "fastq_pass" in path
+
+
+def fastq_dir_glob(data_dir: str, experiment_name: str) -> str:
+    return f"{os.path.join(data_dir, experiment_name)}/*/*/fastq_pass"

--- a/src/nomadic/util/minknow.py
+++ b/src/nomadic/util/minknow.py
@@ -30,8 +30,14 @@ def fastq_dir(fastq_dir_glob: str) -> Optional[str]:
 
 
 def is_fastq_dir(path: str) -> bool:
-    return "fastq_pass" in path
+    return (
+        path.endswith("fastq_pass") or path.endswith("fastq_pass/")
+    ) and os.path.isdir(path)
 
 
 def fastq_dir_glob(data_dir: str, experiment_name: str) -> str:
-    return f"{os.path.join(data_dir, experiment_name)}/*/*/fastq_pass"
+    if not data_dir.endswith(experiment_name) and not data_dir.endswith(
+        f"{experiment_name}/"
+    ):
+        data_dir = os.path.join(data_dir, experiment_name)
+    return f"{data_dir}/*/*/fastq_pass"


### PR DESCRIPTION
We want to allow the user to start nomadic directly and some of the output directories might not exist yet.

We check that the path that the
user provides exists, or error out. But the user does can also only provide the path only of the data directory of minknow (the default). In this case we will keep checking for the folders with a glob pattern and only warn the users that the files don't exist yet.