### PR TITLE
Correcting Metadatafile columns

### DIFF
--- a/src/nomadic/realtime/commands.py
+++ b/src/nomadic/realtime/commands.py
@@ -11,6 +11,7 @@ from nomadic.util.workspace import (
     check_if_workspace,
     looks_like_a_bed_filepath,
 )
+from nomadic.util.exceptions import MetadataFormatError
 
 
 def complete_experiment_name(ctx: click.Context, param, incomplete):
@@ -223,14 +224,20 @@ def realtime(
 
     from .main import main
 
-    main(
-        experiment_name,
-        output,
-        workspace_path,
-        fastq_dir,
-        metadata_csv,
-        region_bed,
-        reference_name,
-        caller,
-        verbose,
-    )
+    try:
+        main(
+            experiment_name,
+            output,
+            workspace_path,
+            fastq_dir,
+            metadata_csv,
+            region_bed,
+            reference_name,
+            caller,
+            verbose,
+        )
+    except MetadataFormatError as e:
+        raise click.BadParameter(
+            param_hint="-m/--metadata_csv",
+            message=str(e),
+        ) from e

--- a/src/nomadic/util/_test_data/metadata/sample_info_column_correction_case.csv
+++ b/src/nomadic/util/_test_data/metadata/sample_info_column_correction_case.csv
@@ -1,0 +1,6 @@
+﻿BARCODE,SAMPLE_ID,parasite_per_ul,location,platform
+barcode01,3D7 (NB01),10000,Oxford,flongle
+barcode02,Dd2 (NB02),10000,Oxford,flongle
+barcode03,CamC580Y (NB03),10000,Oxford,flongle
+barcode04,GB4 (NB04),10000,Oxford,flongle
+barcode05,HB3 (NB05),10000,Oxford,flongle

--- a/src/nomadic/util/_test_data/metadata/sample_info_column_correction_other.csv
+++ b/src/nomadic/util/_test_data/metadata/sample_info_column_correction_other.csv
@@ -1,0 +1,6 @@
+﻿Barcodes,sample-ids,parasite_per_ul,location,platform
+barcode01,3D7 (NB01),10000,Oxford,flongle
+barcode02,Dd2 (NB02),10000,Oxford,flongle
+barcode03,CamC580Y (NB03),10000,Oxford,flongle
+barcode04,GB4 (NB04),10000,Oxford,flongle
+barcode05,HB3 (NB05),10000,Oxford,flongle

--- a/src/nomadic/util/_test_data/metadata/sample_info_column_correction_plural.csv
+++ b/src/nomadic/util/_test_data/metadata/sample_info_column_correction_plural.csv
@@ -1,0 +1,6 @@
+﻿barcodes,SAMPLE_IDS,parasite_per_ul,location,platform
+barcode01,3D7 (NB01),10000,Oxford,flongle
+barcode02,Dd2 (NB02),10000,Oxford,flongle
+barcode03,CamC580Y (NB03),10000,Oxford,flongle
+barcode04,GB4 (NB04),10000,Oxford,flongle
+barcode05,HB3 (NB05),10000,Oxford,flongle

--- a/src/nomadic/util/_test_data/metadata/sample_info_column_correction_sample.csv
+++ b/src/nomadic/util/_test_data/metadata/sample_info_column_correction_sample.csv
@@ -1,0 +1,6 @@
+﻿Barcode,Sample,parasite_per_ul,location,platform
+barcode01,3D7 (NB01),10000,Oxford,flongle
+barcode02,Dd2 (NB02),10000,Oxford,flongle
+barcode03,CamC580Y (NB03),10000,Oxford,flongle
+barcode04,GB4 (NB04),10000,Oxford,flongle
+barcode05,HB3 (NB05),10000,Oxford,flongle

--- a/src/nomadic/util/_test_data/metadata/sample_info_column_correction_space.csv
+++ b/src/nomadic/util/_test_data/metadata/sample_info_column_correction_space.csv
@@ -1,0 +1,6 @@
+﻿Barcode,Sample ID
+Barcode1,3D7 (NB01)
+Barcode2,Dd2 (NB02)
+Barcode3,CamC580Y (NB03)
+Barcode4,GB4 (NB04)
+Barcode5,HB3 (NB05)

--- a/src/nomadic/util/_test_data/metadata/sample_info_column_correction_underscore.csv
+++ b/src/nomadic/util/_test_data/metadata/sample_info_column_correction_underscore.csv
@@ -1,0 +1,6 @@
+﻿Barcode,sample_ID,parasite_per_ul,location,platform
+Barcode1,3D7 (NB01),10000,Oxford,flongle
+Barcode2,Dd2 (NB02),10000,Oxford,flongle
+Barcode3,CamC580Y (NB03),10000,Oxford,flongle
+Barcode4,GB4 (NB04),10000,Oxford,flongle
+Barcode5,HB3 (NB05),10000,Oxford,flongle

--- a/src/nomadic/util/metadata.py
+++ b/src/nomadic/util/metadata.py
@@ -87,6 +87,7 @@ class MetadataTableParser:
     """
 
     REQUIRED_COLUMNS = ["barcode", "sample_id"]
+    UNIQUE_COLUMNS = ["barcode"]
 
     def __init__(self, metadata_csv: str, include_unclassified: bool = True):
         """
@@ -133,7 +134,7 @@ class MetadataTableParser:
 
         """
 
-        for c in self.REQUIRED_COLUMNS:
+        for c in self.UNIQUE_COLUMNS:
             all_entries = self.df[c].tolist()
             observed_entries = []
             for entry in all_entries:

--- a/src/nomadic/util/metadata_test.py
+++ b/src/nomadic/util/metadata_test.py
@@ -1,5 +1,5 @@
 import pytest
-from nomadic.util.metadata import check_barcode_format, MetadataTableParser
+from nomadic.util.metadata import correct_barcode_format, MetadataTableParser
 from nomadic.util.exceptions import MetadataFormatError
 
 
@@ -17,7 +17,7 @@ from nomadic.util.exceptions import MetadataFormatError
     ],
 )
 def test_check_barcode_format_good(barcode, try_to_fix, expected):
-    assert check_barcode_format(barcode, try_to_fix) == expected
+    assert correct_barcode_format(barcode, try_to_fix) == expected
 
 
 @pytest.mark.parametrize(
@@ -29,7 +29,7 @@ def test_check_barcode_format_good(barcode, try_to_fix, expected):
 )
 def test_check_barcode_warning(barcode, try_to_fix, expected):
     with pytest.warns(UserWarning):
-        assert check_barcode_format(barcode, try_to_fix) == expected
+        assert correct_barcode_format(barcode, try_to_fix) == expected
 
 
 @pytest.mark.parametrize(
@@ -43,7 +43,7 @@ def test_check_barcode_warning(barcode, try_to_fix, expected):
 def test_check_barcode_warning_error(barcode, try_to_fix, expected):
     with pytest.warns(UserWarning):
         with pytest.raises(MetadataFormatError):
-            assert check_barcode_format(barcode, try_to_fix) == expected
+            assert correct_barcode_format(barcode, try_to_fix) == expected
 
 
 # --------------------------------------------------------------------------------
@@ -106,3 +106,34 @@ def test_metadata_errors(csv_path, error_msg):
     with pytest.raises(MetadataFormatError) as excinfo:
         _ = MetadataTableParser(csv_path)
     assert str(excinfo.value) == error_msg
+
+
+@pytest.mark.parametrize(
+    "csv_path",
+    [
+        test_files_folder + "metadata/sample_info_column_correction_case.csv",
+        test_files_folder + "metadata/sample_info_column_correction_plural.csv",
+        test_files_folder + "metadata/sample_info_column_correction_other.csv",
+        test_files_folder + "metadata/sample_info_column_correction_space.csv",
+        test_files_folder + "metadata/sample_info_column_correction_underscore.csv",
+    ],
+)
+def test_metadata_column_corrections(csv_path):
+    meta_table = MetadataTableParser(csv_path)
+    assert "barcode" in meta_table.df.columns
+    assert "sample_id" in meta_table.df.columns
+
+    assert meta_table.df["barcode"].tolist() == [
+        "barcode01",
+        "barcode02",
+        "barcode03",
+        "barcode04",
+        "barcode05",
+    ]
+    assert meta_table.df["sample_id"].tolist() == [
+        "3D7 (NB01)",
+        "Dd2 (NB02)",
+        "CamC580Y (NB03)",
+        "GB4 (NB04)",
+        "HB3 (NB05)",
+    ]


### PR DESCRIPTION
This Pr does two things:
 - Remove the check that sample ids need to be unique. It should not be a requirement as our logic does not depend on the sample id to be unique. 
 - Correct Metadata file columns, so that if the user write Barcodes instead of barcode, it still works. 